### PR TITLE
hero: lock side-image baselines (overflow-hidden) + tiny md+/lg+/xl+ …

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,14 +47,14 @@ function Hero() {
         >
           {/* LEFT image — locked to column 1, baseline bottom */}
           <div className="hidden md:flex md:col-start-1 md:col-end-2 justify-self-end self-end">
-            <div className="w-[260px] sm:w-[300px] lg:w-[360px] aspect-square">
-              <span className="relative md:top-[14px] lg:top-[18px] xl:top-[20px] inline-block"><img
+            <div className="w-[260px] sm:w-[300px] lg:w-[360px] aspect-square overflow-hidden">
+              <img
                 src="/img/man-blueprint.png"
                 alt="Engineer with blueprint"
                 width={360} height={360}
-                className="w-full h-full object-contain object-bottom"
+                className="w-full h-full object-contain object-bottom relative md:top-[12px] lg:top-[16px] xl:top-[18px]"
                 decoding="async" loading="eager" draggable={false}
-              /></span>
+              />
             </div>
           </div>
 
@@ -72,7 +72,7 @@ function Hero() {
 
           {/* RIGHT image — locked to column 3, baseline bottom */}
           <div className="hidden md:flex md:col-start-3 md:col-end-4 justify-self-start self-end">
-            <div className="w-[260px] sm:w-[300px] lg:w-[360px] aspect-square">
+            <div className="w-[260px] sm:w-[300px] lg:w-[360px] aspect-square overflow-hidden">
               <img
                 src="/img/man-key.png"
                 alt="Owner with keys"
@@ -246,6 +246,7 @@ export default function App() {
     </LanguageProvider>
   );
 }
+
 
 
 


### PR DESCRIPTION
…offset on blueprint

## Summary
<!-- 1-2 sentences: what changed -->

## Changes
- [ ] UI: …
- [ ] Logic: …
- [ ] Styles/Tailwind: …
- [ ] Config: …

## Acceptance Criteria
- [ ] Build passes locally (`npm run build`)
- [ ] No new deps added
- [ ] No CLS; header/footer stable
- [ ] Accessible focus states

## Screenshots / Diffs
<!-- attach screenshot or diff summary -->

## Checklist
- [ ] Small, atomic PR (<200 lines)
- [ ] Updated docs if needed
- [ ] Linked issue (if exists): #123

## Reviewer Notes
<!-- steps for reviewer to verify -->
